### PR TITLE
parsing: google now uses em dash

### DIFF
--- a/harvest.py
+++ b/harvest.py
@@ -56,9 +56,9 @@ import re
 # If modifying these scopes, delete the file token.json.
 SCOPES = 'https://www.googleapis.com/auth/gmail.readonly'
 
-author_rx = re.compile("^(.*) - new articles$")
-citing_rx = re.compile("^(.*) - new citations$")
-related_rx = re.compile("^(.*) - new related research$")
+author_rx = re.compile("^(.*) [-–] new articles$")
+citing_rx = re.compile("^(.*) [-–] new citations$")
+related_rx = re.compile("^(.*) [-–] new related research$")
 
 class Paper:
     def __init__(self, url, desc):


### PR DESCRIPTION
Instead of ascii hyphen, Google now uses Unicode EM DASH https://www.fileformat.info/info/unicode/char/2014/index.htm

Well supported in Python regexp